### PR TITLE
Update `__init__.py` to fix typo in docstring

### DIFF
--- a/src/pvgmsh/__init__.py
+++ b/src/pvgmsh/__init__.py
@@ -29,10 +29,9 @@ def frontal_delaunay_2d(
         (i.e. point ids are identical in the input and
         source).
 
-
     target_size : float, optional
         Target mesh size close to the points.
-        Defalut max size of edge_source in each direction.
+        Default max size of edge_source in each direction.
 
     Returns
     -------


### PR DESCRIPTION
Update __init__.py to fix typo in docstring.