### PR TITLE
Fix the path of markdown document to use for label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,7 +4,7 @@ documentation:
           - any-glob-to-any-file: "docs/**/*"
           - any-glob-to-any-file: "examples/**/*"
           - any-glob-to-any-file: "examples_trame/**/*"
-          - any-glob-to-any-file: "./*.md"
+          - any-glob-to-any-file: "*.md"
 maintenance:
   - any:
       - changed-files:


### PR DESCRIPTION
Fix the path of the markdown document to use for the label.