### PR TITLE
Bump flake8-isort to 6.1.1 to resolve py312 error 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
-          ["flake8-black==0.3.6", "flake8-isort==6.0.0", "flake8-quotes==3.3.2"]
+          ["flake8-black==0.3.6", "flake8-isort==6.1.1", "flake8-quotes==3.3.2"]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Bump flake8-isort to 6.1.1.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- None

<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

<!-- END doctoc generated TOC please keep comment here to allow auto update -->
